### PR TITLE
Puppet can't find pem2certmgrCA 

### DIFF
--- a/lib/puppet/type/pem2certmgrca.rb
+++ b/lib/puppet/type/pem2certmgrca.rb
@@ -1,4 +1,4 @@
-Puppet::Type.newtype(:pem2certmgrCA) do
+Puppet::Type.newtype(:pem2certmgrca) do
   ensurable
 
   newparam(:path, namevar: true) do


### PR DESCRIPTION
I tried making the resource lowercase which seems to have fixed the issue.  When I was using this module using Puppet 6 and trying to use this resource on a windows 2016 machine, the resource failed to apply, because it couldn't find the resource.  Making it all lower case seems to have helped.

If I did something foolish, I'm open to someone telling me that too :-)

Error was:

Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Unknown resource type: 'pem2certmgrCA' 